### PR TITLE
Fix `% Ambiguous command` in 3-Services

### DIFF
--- a/3-Services/Leaf1.cfg
+++ b/3-Services/Leaf1.cfg
@@ -14,7 +14,7 @@ interface Ethernet4
 !
 router bgp 65001
    vlan 112
-      rd 10.0.1.11 : 112
+      rd 10.0.1.11:112
       route-target export 112:112
       route-target import 112:112
       redistribute learned

--- a/3-Services/Leaf2.cfg
+++ b/3-Services/Leaf2.cfg
@@ -14,7 +14,7 @@ interface Ethernet4
 !
 router bgp 65001
    vlan 112
-      rd 10.0.1.11 : 112
+      rd 10.0.1.11:112
       route-target export 112:112
       route-target import 112:112
       redistribute learned

--- a/3-Services/Leaf3.cfg
+++ b/3-Services/Leaf3.cfg
@@ -14,7 +14,7 @@ interface Ethernet4
 !
 router bgp 65001
    vlan 112
-      rd 10.0.1.13 : 112
+      rd 10.0.1.13:112
       route-target export 112:112
       route-target import 112:112
       redistribute learned

--- a/3-Services/Leaf4.cfg
+++ b/3-Services/Leaf4.cfg
@@ -14,7 +14,7 @@ interface Ethernet4
 !
 router bgp 65001
    vlan 112
-      rd 10.0.1.13 : 112
+      rd 10.0.1.13:112
       route-target export 112:112
       route-target import 112:112
       redistribute learned


### PR DESCRIPTION
Since I missed the error message initially, without this command we can observe that the following are empty:
* `sh mac-address table` is ok but `sh vxlan address-table` is empty (meaning vxlan/vtep communication is NOK according to docs)
* `sh vxlan flood vtep`
* `sh bgp evpn summary` is ok (peering established with spines RR)
* `sh bgp evpn`  -> empty control-plane, like no flood list configured on vni (-> vxlan conf is incomplete, as seen before)
* `sh bgp evpn route-type imet`
* `sh bgp evpn route-type mac-ip`